### PR TITLE
Fixed IPC - system V

### DIFF
--- a/drill.txt
+++ b/drill.txt
@@ -237,7 +237,7 @@ a) usuwa funkcje ze zbioru funkcji czyszczących wątku
 d) blokuje proces
 
 IPC - system V) Jaką wartość można ustawić jako trzeci argument funkcji semget?
->>>a) IPC_PRIVATE
+a) IPC_PRIVATE
 >>>b) IPC_CREATE  
 c) IPC_NOWAIT  
 d) SEM_UNDO


### PR DESCRIPTION
IPC_PRIVATE może być przyjmowane wyłącznie jako pierwszy, nie trzeci argument funkcji int semget(key_t key, int nsems, int semflg)

Źródło: http://man7.org/linux/man-pages/man2/semget.2.html